### PR TITLE
Updated readme to include Tailwind usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,18 @@ cd react-image-magnifiers
 npm install
 npm start
 ```
+
+## Notes for Tailwind CSS
+
+When using magnifiers with Tailwind CSS there is a css rule that prevents magnifiers to correctly work:
+```
+img {
+     max-width: 100%;
+}
+```
+To solve the issue, simply remove the above rule or set the following one
+```
+img {
+    max-width: unset !important;
+}
+```


### PR DESCRIPTION
Tailwind CSS has a conflicting css rules that prevents magnifiers to correctly work with. Tailwind CSS is a widely used css framework, often combined with NextJS so it is really important to notify users that there is a really super simple fix to be able to use React Image Magnifiers with Tailwind CSS based components.